### PR TITLE
ISSUE-4: Clarify dev env instructions

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -1,70 +1,37 @@
-# OpenVMP
+# Configuring the OpenVMP development environment
 
-## Configuring the development environment
+## Installing
+Install ROS2 Humble, Gazebo, other development packages, and OpenVMP on an Ubuntu 22.04 system.
 
-### OS
+1. Follow the [ROS2 installation instructions](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html). Choose the Desktop Install and also install the Development Tools.
 
-The following instructions are for Ubuntu 22.04.
-If you would like to use another OS for development
-then simply [use docker](../docker/dev/README.md).
-
-### OS prerequisites
-
-Use the following instructions to prepare the ROS2 environment on a vanilla Ubuntu 22.04 (not a docker container with ROS2 Humble preinstalled):
+2. As per the [Gazebo Humble instructions](https://gazebosim.org/docs/garden/ros_installation#ros-2-humble-and-ros-2-rolling), run this command: 
 
 ```bash
-sudo -s
-apt update
-apt install -y software-properties-common
-add-apt-repository universe
-apt update
-apt install -y git curl gnupg lsb-release
-curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(source /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null
+sudo apt install -y ros-humble-ros-gz
 ```
 
-The following OS packages are required for development and testing purposes:
+3. OpenVMP requires these additional packages:
 
 ```bash
-apt install -y socat xterm
-
-apt install -y ansible
+sudo apt install -y git gnupg lsb-release
+sudo apt install -y socat xterm
+sudo apt install -y ansible
 ansible-galaxy collection install community.general
 ```
 
-### ROS2 package prerequisites
-
-The following packages might be missing from your ROS2 environment and
-need to be installed additionally:
+4. Clone OpenVMP:
 
 ```bash
-sudo -s
-apt update
-apt install -y ros-humble-desktop-full python3-colcon-common-extensions
-apt install -y ros-humble-ros2-control ros-humble-ros2-controllers
-apt install -y ros-humble-gazebo-ros-pkgs ros-humble-gazebo-ros2-control
-apt install -y ros-humble-camera-calibration-parsers v4l2loopback-utils
-apt install -y ros-humble-topic-tools ros-humble-robot-localization
-apt install -y ros-humble-ros-testing
+git clone --recurse-submodules git://github.com/openvmp/openvmp.git
 ```
-
-### Visual Studio Code
-
-Open the top level OpenVMP folder as a workspace in Visual Studio Code.
-
-If you open any C++ file in Visual Studio Code
-then there will be a large number of C++ errors reported.
-The whole platform needs to be built at least once to have the neccessary
-support files generated and to have those error messages go away.
 
 ## Building
 
-In order to build and use all OpenVMP ROS2 packages, use the following commands:
+Set the ROS2 underlay, cd into the OpenVMP overlay, and build:
 
 ```bash
 source /opt/ros/humble/setup.bash  # or .zsh instead of .bash
-git clone --recurse-submodules git://github.com/openvmp/openvmp.git
 cd openvmp/platform
 COLCON_HOME=$(pwd) colcon build
 source ./install/local_setup.bash  # or .zsh instead of .bash
@@ -72,13 +39,10 @@ source ./install/local_setup.bash  # or .zsh instead of .bash
 
 ## Testing
 
-In order to see how most of the software modules play together,
-use the following command:
+Start an RViz window with a single robot using dumb hardware stubs:
 
 ```bash
 ros2 launch openvmp_robot robot.launch.py use_fake_hardware:=true
 ```
 
-It will start an RViz window with a single robot using dumb hardware stubs.
-Click on the yellow circle under the robot
-to switch to any of the supported manual control modes.
+Click the yellow circle under the robot to select a manual control mode.

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -18,12 +18,16 @@ sudo apt install -y git gnupg lsb-release
 sudo apt install -y socat xterm
 sudo apt install -y ansible
 ansible-galaxy collection install community.general
+sudo apt install v4l2loopback-utils
+sudo apt install -y ros-humble-ros2-control ros-humble-ros2-controllers
+sudo apt install -y ros-humble-camera-calibration-parsers ros-humble-camera-info-manager
+sudo apt install -y ros-humble-gazebo-dev ros-humble-gazebo-ros
 ```
 
 4. Clone OpenVMP:
 
 ```bash
-git clone --recurse-submodules git://github.com/openvmp/openvmp.git
+git clone --recurse-submodules https://github.com/openvmp/openvmp.git
 ```
 
 ## Building


### PR DESCRIPTION
[Problem]
- Incorrect copy of official ROS2 install instructions.
- "ROS2 package prerequisites" is an accumulation of trial and error,
  the explanation of which we do not remember.

[Solution]
- Refer the user to the official ROS2 and Gazebo install instructions.
- Ran through a clean install. Discovered which additional packages the build requires.

[Test]
- Manually followed steps. The build completed. Testing failed to launch. 
  Attached the shell output to the issue. Let's deal with the test failure in a separate issue.

[Links]
- https://github.com/openvmp/openvmp/issues/4