### PR TITLE
ISSUE-8: package topic_tools not found

### DIFF
--- a/docs/Development.md
+++ b/docs/Development.md
@@ -22,6 +22,7 @@ sudo apt install v4l2loopback-utils
 sudo apt install -y ros-humble-ros2-control ros-humble-ros2-controllers
 sudo apt install -y ros-humble-camera-calibration-parsers ros-humble-camera-info-manager
 sudo apt install -y ros-humble-gazebo-dev ros-humble-gazebo-ros
+sudo apt install -y ros-humble-topic-tools
 ```
 
 4. Clone OpenVMP:


### PR DESCRIPTION
[Problem]
- The launch command from docs/Development.md exits with error "package topic_tools not found".

[Solution]
- Install the ROS topic_tools package (the package is not part of the base ROS install).

[Test]
- Manual test (jammy amd64)

[Links]
- https://github.com/openvmp/openvmp/issues/8